### PR TITLE
Update updatedAt even when present

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -310,7 +310,7 @@ Table.prototype.update = function (item, options, callback) {
   const start = (callback) => {
     const paramName = _.isString(self.schema.updatedAt) ? self.schema.updatedAt : 'updatedAt';
 
-    if (self.schema.timestamps && self.schema.updatedAt !== false && !_.has(item, paramName)) {
+    if (self.schema.timestamps && self.schema.updatedAt !== false) {
       item[paramName] = new Date().toISOString();
     }
 


### PR DESCRIPTION
The check to see if timestamps is on and that updatedAt is not turned off should be sufficient reason to refresh the updatedAt property even if it exists on the item.