### PR TITLE
Allow disable partial validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ var Tweet = dynogels.define('Tweet', {
 #### Data Validation
 Dynogels automatically validates the model against the schema before attempting to save it, but you can also call the `validate` method to validate an object before saving it. This can be helpful for a handler to validate input.
 
+As an option, you can disable validation with the `validate: false` option when calling `Table.update(...)`.  On partial updates, it is often impossible to safely validate part of a model (since there might be validation dependencies on other, unprovided properties).
+
 ```js
 var Tweet = dynogels.define('Tweet', {
   hashKey : 'TweetID',

--- a/lib/table.js
+++ b/lib/table.js
@@ -299,12 +299,14 @@ Table.prototype.update = function (item, options, callback) {
   callback = callback || _.noop;
   options = options || {};
 
-  const schemaValidation = internals.validateItemFragment(item, self.schema);
-  if (schemaValidation.error) {
-    return callback(_.assign(new Error(`Schema validation error while updating item in table ${self.tableName()}: ${JSON.stringify(schemaValidation.error)}`), {
-      name: 'DynogelsUpdateError',
-      detail: schemaValidation.error
-    }));
+  if (options.validate !== false) {
+    const schemaValidation = internals.validateItemFragment(item, self.schema);
+    if (schemaValidation.error) {
+      return callback(_.assign(new Error(`Schema validation error while updating item in table ${self.tableName()}: ${JSON.stringify(schemaValidation.error)}`), {
+        name: 'DynogelsUpdateError',
+        detail: schemaValidation.error
+      }));
+    }
   }
 
   const start = (callback) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,7 @@
       "version": "2.504.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.504.0.tgz",
       "integrity": "sha512-azOX54oovJv0zWzO23fBgIprwsvx8KUuMR+cAUAOx23D8LJ5S+sl3UYS9Q1X4qF/blBTa4+ZNawZDV0N1HiQmw==",
+      "dev": true,
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -188,7 +189,8 @@
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "dev": true
         }
       }
     },
@@ -248,7 +250,8 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -279,6 +282,7 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dev": true,
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
@@ -867,7 +871,8 @@
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
     },
     "extend": {
       "version": "3.0.2",
@@ -1162,7 +1167,8 @@
     "ieee754": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
     },
     "ignore": {
       "version": "3.3.10",
@@ -1247,7 +1253,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isemail": {
       "version": "3.2.0",
@@ -1351,7 +1358,8 @@
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "dev": true
     },
     "joi": {
       "version": "11.4.0",
@@ -1976,7 +1984,8 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -1987,7 +1996,8 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -2164,7 +2174,8 @@
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
     },
     "semver": {
       "version": "5.7.0",
@@ -2524,6 +2535,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dev": true,
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
@@ -2607,6 +2619,7 @@
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dev": true,
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"
@@ -2615,7 +2628,8 @@
     "xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "license": "MIT",
   "dependencies": {
     "async": "2.5.0",
-    "aws-sdk": "^2.408.0",
     "lodash": "^4.17.15",
     "uuid": "3.1.0"
   },
   "devDependencies": {
+    "aws-sdk": "^2.408.0",
     "chai": "4.1.2",
     "coveralls": "3.0.0",
     "eslint": "4.19.1",
@@ -45,6 +45,7 @@
     "sinon": "4.0.1"
   },
   "peerDependencies": {
+    "aws-sdk": "^2.408.0",
     "joi": "^11.3.4"
   }
 }


### PR DESCRIPTION
When calling <table>.update, allow options object to disable validation with `{ validate: false }`.  By default, dynogels will continue to perform partial schema validation on update, which may not be feasible with schemas whose fields' validity is dependent on the values of other, unspecified fields.